### PR TITLE
fix of unexpected magnifying glass on iOS when intensed img is open

### DIFF
--- a/_app/assets/themes/curtana/_less/plugins.less
+++ b/_app/assets/themes/curtana/_less/plugins.less
@@ -17,6 +17,12 @@
   &.intense-open {
     cursor: zoom-out;
   }
+  
+  .intense-open {
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    -moz-user-select: none;
+  }
 }
 
 // GitHub Gist


### PR DESCRIPTION
user may encounter iOS native magnifying glass when they try to move here and there in intense.js created full-screen image.
this PR is a reasonable fix.

[test](http://hl0.co/suibiancheche/2016/01/29/r/)