### PR TITLE
Fixing the tzinfo not working problem on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,14 @@ end
 group :jekyll_plugins do
   gem "match_regex"
 end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+  gem "tzinfo", "2.0.2"
+  gem "tzinfo-data"
+end
+
+
+# this solves error from the grunt
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
This I believe is a common problem on windows where the error says that we don't have tzinfo or one of its dependencies installed but we had installed tz-info before.

Adding this line of code fixed the common problem.